### PR TITLE
More logical keybinding CTRL+SHIFT+S

### DIFF
--- a/keymaps/atom-save-all.cson
+++ b/keymaps/atom-save-all.cson
@@ -8,4 +8,4 @@
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
 'atom-text-editor':
-  'ctrl-s': 'atom-save-all:saveAll'
+  'ctrl-shift-s': 'atom-save-all:saveAll'


### PR DESCRIPTION
Instead replacing the standard CTRL+S for save a single file, it is better to replace the "Save as..." command
